### PR TITLE
Remove SMSFactor SDK fork usage in favor of dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": ">=7.4.0 <8.1",
     "mautic/core-lib": "^4.0",
-    "smsfactor/smsfactor-php-sdk": "dev-patch-1 as 1.0.5",
+    "smsfactor/smsfactor-php-sdk": "dev-master",
     "php-http/message-factory": "^1.0@dev"
   },
   "require-dev": {
@@ -36,12 +36,6 @@
     "phpstan/phpstan-doctrine": "^1.3",
     "phpstan/phpstan": "^1.10"
   },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/ogizanagi/smsfactor-php-sdk"
-    }
-  ],
   "config": {
     "allow-plugins": {
       "symfony/flex": true,


### PR DESCRIPTION
Since https://github.com/smsfactor/smsfactor-php-sdk/pull/6 was merged (but not released yet)