### PR TITLE
Set correct dedicated Mautic application code

### DIFF
--- a/Transport/SmsFactorTransport.php
+++ b/Transport/SmsFactorTransport.php
@@ -133,6 +133,7 @@ class SmsFactorTransport implements TransportInterface
         }
 
         SMSFactor::setApiToken($apiToken);
+        SMSFactor::setApplicationCode(33); // Dedicated Mautic application code. Do not change it.
     }
 
     private function getTextMessageContent(string $content): string

--- a/Transport/SmsFactorTransport.php
+++ b/Transport/SmsFactorTransport.php
@@ -133,7 +133,7 @@ class SmsFactorTransport implements TransportInterface
         }
 
         SMSFactor::setApiToken($apiToken);
-        SMSFactor::setApplicationCode(33); // Dedicated Mautic application code. Do not change it.
+        SMSFactor::setApplicationCode('33'); // Dedicated Mautic application code. Do not change it.
     }
 
     private function getTextMessageContent(string $content): string


### PR DESCRIPTION
The MauticBundle used the default PHP SDK application code. We created a dedicated one for Mautic which is code 33.